### PR TITLE
Configure Dependabot some more

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,11 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "sunday"
       time: "08:00"
       timezone: "America/Los_Angeles"
     assignees:
       - "wllmwu"
     labels:
       - "maintenance"
-    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,14 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "monthly" # Runs on the 1st
       time: "08:00"
       timezone: "America/Los_Angeles"
     assignees:
       - "wllmwu"
     labels:
       - "maintenance"
+    ignore:
+      - update-types:
+          - "version-update:semver-patch"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
     labels:
       - "maintenance"
     ignore:
-      - update-types:
+      - dependency-name: "*"
+        update-types:
           - "version-update:semver-patch"
     open-pull-requests-limit: 10

--- a/.github/workflows/merge-dependabot.yml
+++ b/.github/workflows/merge-dependabot.yml
@@ -1,0 +1,24 @@
+# Based on the example here: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request
+
+name: Auto-merge Dependabot updates
+
+on: pull_request
+
+permissions:
+  contents: write
+
+jobs:
+  merge:
+    name: Merge
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.3
+      - name: Enable auto-merge
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

- Set Dependabot to check dependencies monthly and ignore semver patch updates
- Add Actions workflow to enable auto-merge on Dependabot PRs for semver minor updates (will merge major updates manually)
  - Untested because it's hard to test GitHub Actions

## Resolutions

- Resolves #48
